### PR TITLE
Refactor Readme to specify a version of eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You need a working copy of npm, the package manager that comes bundled with [Nod
 Using npm, install ESLint:
 
 ```
-npm install -g eslint
+npm install -g eslint@6.8.0
 ```
 
 ## Installation


### PR DESCRIPTION
Pomander has an incompatibility with the newest version of eslint (7.0+) on Linux machines and may have issues on MacOS at some point in the future. Instructions are refactored to provide long-term stability by specifying the latest non-breaking version in the npm install command (6.8.0)